### PR TITLE
Update GitHub Actions workflow to trigger on pull_request_target

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,8 +9,8 @@
 
 name: Labeler
 on:
-  #pull_request_target
-  - pull_request
+  - pull_request_target
+  #- pull_request
   #  types: [opened, synchronize, reopened, edited, labeled, unlabeled]
 
 jobs:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/labeler.yml` file. The change modifies the GitHub Actions workflow trigger to use `pull_request_target` instead of `pull_request`.

Workflow trigger modification:

* [`.github/workflows/labeler.yml`](diffhunk://#diff-09b72f3c9a3e4f00ab00cd7000b302db25f056075d8895bd91b3654d6e7e956bL12-R13): Changed the workflow trigger from `pull_request` to `pull_request_target` to ensure the workflow runs with the correct permissions.